### PR TITLE
Fix session host spawning and .env loading in production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx watch --env-file=.env src/index.ts",
     "test": "vitest run",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node --env-file=.env dist/index.js"
   },
   "dependencies": {
     "express": "^5.1.0",

--- a/src/core/process-manager.ts
+++ b/src/core/process-manager.ts
@@ -167,8 +167,10 @@ export class ProcessManager {
       channelContext: { channel, adapter: adapterNames[adapterPrefix] || adapterPrefix },
     });
 
-    const sessionHostPath = resolve(import.meta.dirname, 'session-host.ts');
-    const hostProc = spawn('tsx', [sessionHostPath, hostConfig], {
+    const ext = import.meta.filename.endsWith('.ts') ? '.ts' : '.js';
+    const sessionHostPath = resolve(import.meta.dirname, `session-host${ext}`);
+    const runner = ext === '.ts' ? 'tsx' : 'node';
+    const hostProc = spawn(runner, [sessionHostPath, hostConfig], {
       detached: true,
       stdio: 'ignore',
       cwd: this.config.cwd,


### PR DESCRIPTION
## Summary

- **Session host never starts with `npm start`**: The process manager hardcoded `tsx` + `.ts` extension for spawning session hosts. When running the compiled build (`node dist/index.js`), the files are `.js` — so the detached process silently failed and the Unix socket was never created, causing `Failed to connect to session host` errors on every message.
- **Environment variables missing in production**: The `start` script ran `node dist/index.js` without `--env-file=.env`, so tokens like `BARECLAW_TELEGRAM_TOKEN` were never loaded.

## Changes

- Detect runtime extension via `import.meta.filename` and use `node` for compiled `.js` builds, `tsx` for `.ts` dev mode
- Add `--env-file=.env` to the `start` script in `package.json`

## Test plan

- [ ] `npm run build && npm start` — verify Telegram adapter starts and session hosts spawn successfully
- [ ] `npm run dev` — verify dev mode still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)